### PR TITLE
Enhance payload size detection and improve benchmark documentation

### DIFF
--- a/src/errorcodes.cpp
+++ b/src/errorcodes.cpp
@@ -34,6 +34,8 @@ const std::string errorcode(benchmark_result::operation_outcome_t outcome) {
         overloaded {
             [&](benchmark_result::Ok) -> std::string { return "CKR_OK"; },
             [&](benchmark_result::NotFound const& nf) -> std::string { return nf.what(); },
+            [&](benchmark_result::AmbiguousResult const& ar) -> std::string { return ar.what(); },
+            [&](benchmark_result::PayloadSizeNotSupported const& psns) -> std::string { return psns.what(); },
             [&](benchmark_result::ApiErr const& apiErr) -> std::string { return _errorcode(apiErr); }
         }, outcome );
 }

--- a/src/p11aescbc.cpp
+++ b/src/p11aescbc.cpp
@@ -31,6 +31,11 @@ inline P11AESCBCBenchmark *P11AESCBCBenchmark::clone() const {
     return new P11AESCBCBenchmark{*this};
 }
 
+bool P11AESCBCBenchmark::is_payload_supported(size_t payload_size)
+{
+    // AES CBC requires payload to be multiple of block size (16 bytes)
+    return (payload_size % 16) == 0;
+}
 
 void P11AESCBCBenchmark::prepare(Session &session, Object &obj, std::optional<size_t> threadindex)
 {

--- a/src/p11aescbc.hpp
+++ b/src/p11aescbc.hpp
@@ -31,6 +31,7 @@ class P11AESCBCBenchmark : public P11Benchmark
     virtual void prepare(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual void crashtestdummy( Session &session) override;
     virtual P11AESCBCBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11aescbc.hpp
+++ b/src/p11aescbc.hpp
@@ -21,6 +21,38 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: AES-CBC Encryption
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of AES encryption using Cipher
+//   Block Chaining (CBC) mode. It encrypts variable-size payloads using the
+//   CKM_AES_CBC mechanism with a randomly generated initialization vector.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. The test
+//   supports any payload size that is a multiple of the AES block size
+//   (16 bytes). The payload size is specified via command-line options.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_AES (secret key)
+//   - Key sizes: 128, 192, or 256 bits
+//   - The key must be extractable and support encryption operations
+//   - Key attributes: CKA_ENCRYPT must be set to CK_TRUE
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the AES key size (128, 192, or 256)
+//   --payload <bytes>   : Size of data to encrypt (must be multiple of 16)
+//
+// TESTING APPROACH:
+//   The test performs encryption operations in a tight loop, measuring the
+//   throughput. Each iteration encrypts the same payload using the same key
+//   but with the same IV (set during prepare phase). The performance metric
+//   is the number of encryption operations per second and data throughput.
+//
+// ============================================================================
+
 class P11AESCBCBenchmark : public P11Benchmark
 {
     Byte m_iv[16];

--- a/src/p11aesecb.cpp
+++ b/src/p11aesecb.cpp
@@ -27,6 +27,11 @@ inline P11AESECBBenchmark *P11AESECBBenchmark::clone() const {
 	return new P11AESECBBenchmark{*this};
 }
 
+bool P11AESECBBenchmark::is_payload_supported(size_t payload_size)
+{
+    // AES ECB requires payload to be multiple of block size (16 bytes)
+    return (payload_size % 16) == 0;
+}
 
 void P11AESECBBenchmark::prepare(Session &session, Object &obj, std::optional<size_t> threadindex)
 {

--- a/src/p11aesecb.hpp
+++ b/src/p11aesecb.hpp
@@ -21,6 +21,39 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: AES-ECB Encryption
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of AES encryption using Electronic
+//   Codebook (ECB) mode. It encrypts variable-size payloads using the
+//   CKM_AES_ECB mechanism without an initialization vector.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. The test
+//   supports any payload size that is a multiple of the AES block size
+//   (16 bytes). The payload size is specified via command-line options.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_AES (secret key)
+//   - Key sizes: 128, 192, or 256 bits
+//   - The key must be extractable and support encryption operations
+//   - Key attributes: CKA_ENCRYPT must be set to CK_TRUE
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the AES key size (128, 192, or 256)
+//   --payload <bytes>   : Size of data to encrypt (must be multiple of 16)
+//
+// TESTING APPROACH:
+//   The test performs encryption operations in a tight loop, measuring the
+//   throughput. ECB mode processes each block independently, making it
+//   suitable for performance benchmarking but not recommended for production
+//   use due to security considerations. The performance metric is the number
+//   of encryption operations per second and data throughput.
+//
+// ============================================================================
+
 class P11AESECBBenchmark : public P11Benchmark
 {
     Mechanism m_mech_aesecb { CKM_AES_ECB, nullptr, 0 };

--- a/src/p11aesecb.hpp
+++ b/src/p11aesecb.hpp
@@ -30,6 +30,7 @@ class P11AESECBBenchmark : public P11Benchmark
     virtual void prepare(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual void crashtestdummy(Session &session) override;
     virtual P11AESECBBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11aesgcm.hpp
+++ b/src/p11aesgcm.hpp
@@ -23,6 +23,40 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: AES-GCM Encryption
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of AES encryption using Galois/
+//   Counter Mode (GCM), an authenticated encryption mode. It encrypts
+//   variable-size payloads using the CKM_AES_GCM mechanism with a randomly
+//   generated initialization vector and produces an authentication tag.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. Unlike ECB and
+//   CBC modes, GCM does not require the payload to be a multiple of the block
+//   size. The payload size is specified via command-line options.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_AES (secret key)
+//   - Key sizes: 128, 192, or 256 bits
+//   - The key must support encryption operations
+//   - Key attributes: CKA_ENCRYPT must be set to CK_TRUE
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the AES key size (128, 192, or 256)
+//   --payload <bytes>   : Size of data to encrypt (any size supported)
+//
+// TESTING APPROACH:
+//   The test performs authenticated encryption operations in a tight loop.
+//   GCM mode provides both confidentiality and authenticity with a 128-bit
+//   authentication tag. The IV is randomly generated during the prepare phase.
+//   The performance metric is the number of encryption operations per second
+//   and data throughput, including the authentication overhead.
+//
+// ============================================================================
+
 class P11AESGCMBenchmark : public P11Benchmark
 {
     std::vector<uint8_t> m_iv;

--- a/src/p11benchmark.cpp
+++ b/src/p11benchmark.cpp
@@ -108,9 +108,12 @@ benchmark_result::benchmark_result_t P11Benchmark::execute(Session *session, con
 
     // a small lambda to handle exceptions in a uniform way
     auto handle_benchmark_exception = [&](auto const& exc) {
-        std::lock_guard<std::mutex> lg{display_mtx};
-        std::cerr << "ERROR: " << exc.what() << std::endl;
-        return_code = decltype(exc){exc}; 
+        {
+            std::lock_guard<std::mutex> lg{display_mtx};
+            std::cerr << "ERROR: " << exc.what() << std::endl;
+        }
+        using Exc = std::decay_t<decltype(exc)>;
+        return_code = Exc{exc};
     };
 
     try {

--- a/src/p11des3cbc.cpp
+++ b/src/p11des3cbc.cpp
@@ -31,6 +31,11 @@ inline P11DES3CBCBenchmark *P11DES3CBCBenchmark::clone() const {
     return new P11DES3CBCBenchmark{*this};
 }
 
+bool P11DES3CBCBenchmark::is_payload_supported(size_t payload_size)
+{
+    // DES3 CBC requires payload to be multiple of block size (8 bytes)
+    return (payload_size % 8) == 0;
+}
 
 void P11DES3CBCBenchmark::prepare(Session &session, Object &obj, std::optional<size_t> threadindex)
 {

--- a/src/p11des3cbc.hpp
+++ b/src/p11des3cbc.hpp
@@ -21,6 +21,39 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: Triple DES CBC Encryption
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of Triple DES (3DES) encryption
+//   using Cipher Block Chaining (CBC) mode. It encrypts variable-size
+//   payloads using the CKM_DES3_CBC mechanism with a randomly generated
+//   initialization vector.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. The test
+//   supports any payload size that is a multiple of the DES block size
+//   (8 bytes). The payload size is specified via command-line options.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_DES3 (secret key)
+//   - Key size: 168 bits (24 bytes, representing three 56-bit DES keys)
+//   - The key must be extractable and support encryption operations
+//   - Key attributes: CKA_ENCRYPT must be set to CK_TRUE
+//
+// OPTIONS:
+//   --payload <bytes>   : Size of data to encrypt (must be multiple of 8)
+//
+// TESTING APPROACH:
+//   The test performs encryption operations in a tight loop, measuring the
+//   throughput. Each iteration encrypts the same payload using the same key
+//   with the same IV (set during prepare phase). The performance metric is
+//   the number of encryption operations per second and data throughput.
+//   Note: 3DES is slower than AES due to its legacy design.
+//
+// ============================================================================
+
 class P11DES3CBCBenchmark : public P11Benchmark
 {
     Byte m_iv[8];

--- a/src/p11des3cbc.hpp
+++ b/src/p11des3cbc.hpp
@@ -31,6 +31,7 @@ class P11DES3CBCBenchmark : public P11Benchmark
     virtual void prepare(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual void crashtestdummy(Session &session) override;
     virtual P11DES3CBCBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11des3ecb.cpp
+++ b/src/p11des3ecb.cpp
@@ -27,6 +27,11 @@ inline P11DES3ECBBenchmark *P11DES3ECBBenchmark::clone() const {
     return new P11DES3ECBBenchmark{*this};
 }
 
+bool P11DES3ECBBenchmark::is_payload_supported(size_t payload_size)
+{
+    // DES3 ECB requires payload to be multiple of block size (8 bytes)
+    return (payload_size % 8) == 0;
+}
 
 void P11DES3ECBBenchmark::prepare(Session &session, Object &obj, std::optional<size_t> threadindex)
 {

--- a/src/p11des3ecb.hpp
+++ b/src/p11des3ecb.hpp
@@ -21,6 +21,38 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: Triple DES ECB Encryption
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of Triple DES (3DES) encryption
+//   using Electronic Codebook (ECB) mode. It encrypts variable-size payloads
+//   using the CKM_DES3_ECB mechanism without an initialization vector.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. The test
+//   supports any payload size that is a multiple of the DES block size
+//   (8 bytes). The payload size is specified via command-line options.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_DES3 (secret key)
+//   - Key size: 168 bits (24 bytes, representing three 56-bit DES keys)
+//   - The key must be extractable and support encryption operations
+//   - Key attributes: CKA_ENCRYPT must be set to CK_TRUE
+//
+// OPTIONS:
+//   --payload <bytes>   : Size of data to encrypt (must be multiple of 8)
+//
+// TESTING APPROACH:
+//   The test performs encryption operations in a tight loop, measuring the
+//   throughput. ECB mode processes each block independently, making it
+//   suitable for performance benchmarking but not recommended for production
+//   use due to security considerations. The performance metric is the number
+//   of encryption operations per second and data throughput.
+//
+// ============================================================================
+
 class P11DES3ECBBenchmark : public P11Benchmark
 {
     Mechanism m_mech_des3ecb { CKM_DES3_ECB, nullptr, 0 };

--- a/src/p11des3ecb.hpp
+++ b/src/p11des3ecb.hpp
@@ -30,6 +30,7 @@ class P11DES3ECBBenchmark : public P11Benchmark
   virtual void prepare(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual void crashtestdummy(Session &session) override;
     virtual P11DES3ECBBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11ecdh1derive.hpp
+++ b/src/p11ecdh1derive.hpp
@@ -21,6 +21,42 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: ECDH Key Derivation (CKM_ECDH1_DERIVE)
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of key derivation using the
+//   Elliptic Curve Diffie-Hellman (ECDH) protocol. It derives symmetric
+//   keys from EC key pairs using the CKM_ECDH1_DERIVE mechanism, which
+//   implements the shared secret computation.
+//
+// PAYLOAD:
+//   The payload in this context is the EC public key point of the peer,
+//   which is provided in the ECDH1 derivation parameters. The mechanism
+//   combines the local private key with the peer's public key to derive
+//   a shared secret, which is then used as key material.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_EC (EC private key for derivation)
+//   - Key curves: Supported elliptic curves (e.g., P-256, P-384, P-521)
+//   - The key must support key derivation operations
+//   - Key attributes: CKA_DERIVE must be set to CK_TRUE
+//   - A corresponding EC public key (from a peer) is needed for the operation
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the EC curve size (256, 384, or 521)
+//
+// TESTING APPROACH:
+//   The test uses the CKM_ECDH1_DERIVE mechanism with parameters specifying
+//   the key derivation function (KDF) and the peer's public key point.
+//   During preparation, the peer public key data is extracted and configured
+//   in the derivation parameters. The benchmark loop repeatedly derives new
+//   symmetric keys (e.g., AES keys), measuring derivation operations per
+//   second. After each iteration, the derived key is destroyed to prevent
+//   resource exhaustion.
+//
+// ============================================================================
 
 class P11ECDH1DeriveBenchmark : public P11Benchmark
 {

--- a/src/p11ecdsasig.hpp
+++ b/src/p11ecdsasig.hpp
@@ -21,6 +21,41 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: ECDSA Signature Generation
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of ECDSA (Elliptic Curve Digital
+//   Signature Algorithm) signature generation. It signs pre-computed digests
+//   using EC private keys through the PKCS#11 interface.
+//
+// PAYLOAD:
+//   The payload is a pre-computed hash/digest of the data to be signed.
+//   The digest is generated using Botan's hashing facilities and provided
+//   to the signing operation. The digest size depends on the hash algorithm
+//   used (typically SHA-256, producing a 32-byte digest).
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_EC (EC private key)
+//   - Key curves: Supported elliptic curves (e.g., P-256, P-384, P-521)
+//   - The key must be a private key with signing capabilities
+//   - Key attributes: CKA_SIGN must be set to CK_TRUE
+//   - The key must be accessible via PKCS#11 and usable with Botan's
+//     PKCS11_ECDSA_PrivateKey wrapper
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the EC curve size (256, 384, or 521)
+//
+// TESTING APPROACH:
+//   The test uses Botan's PKCS#11 integration to wrap the EC private key
+//   and create a PK_Signer object. During the prepare phase, the digest
+//   is computed once. The benchmark loop repeatedly signs this digest,
+//   measuring the number of signature operations per second. This approach
+//   isolates the cryptographic signing operation from hashing overhead.
+//
+// ============================================================================
+
 class P11ECDSASigBenchmark : public P11Benchmark
 {
     Botan::AutoSeeded_RNG m_rng;

--- a/src/p11findobjects.cpp
+++ b/src/p11findobjects.cpp
@@ -20,6 +20,7 @@
 #include <random>
 #include <sstream>
 #include <iomanip>
+#include <cstdlib>
 #include <botan/auto_rng.h>
 #include "p11findobjects.hpp"
 
@@ -32,6 +33,24 @@ P11FindObjectsBenchmark::P11FindObjectsBenchmark(const P11FindObjectsBenchmark &
 
 inline P11FindObjectsBenchmark *P11FindObjectsBenchmark::clone() const {
     return new P11FindObjectsBenchmark{*this};
+}
+
+bool P11FindObjectsBenchmark::is_payload_supported(size_t payload_size)
+{
+    // Payload size indicates the number of objects to create
+    // Default max is 512, but can be overridden via P11PERFTEST_FIND_MAXOBJS
+    size_t max_objects = 512;
+    
+    const char* env_max = std::getenv("P11PERFTEST_FIND_MAXOBJS");
+    if (env_max != nullptr) {
+        try {
+            max_objects = std::stoul(env_max);
+        } catch (...) {
+            // If parsing fails, use default value
+        }
+    }
+    
+    return payload_size <= max_objects;
 }
 
 void P11FindObjectsBenchmark::prepare(Session &session, Object &obj, std::optional<size_t> threadindex)
@@ -144,7 +163,7 @@ void P11FindObjectsBenchmark::crashtestdummy(Session &session)
     
     // Verify we found exactly one object
     if (found_count != 1) {
-        throw benchmark_result::NotFound();
+        throw benchmark_result::NotFound(label_data);
     }
 }
 

--- a/src/p11findobjects.cpp
+++ b/src/p11findobjects.cpp
@@ -163,7 +163,7 @@ void P11FindObjectsBenchmark::crashtestdummy(Session &session)
     
     // Verify we found exactly one object
     if (found_count != 1) {
-        throw benchmark_result::NotFound(label_data);
+        throw benchmark_result::NotFound(std::string(label_data, label_len));
     }
 }
 

--- a/src/p11findobjects.hpp
+++ b/src/p11findobjects.hpp
@@ -35,6 +35,7 @@ class P11FindObjectsBenchmark : public P11Benchmark
     virtual void cleanup(Session &session) override;
     virtual void teardown(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual P11FindObjectsBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11findobjects.hpp
+++ b/src/p11findobjects.hpp
@@ -21,6 +21,69 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: Object Search Performance (C_FindObjects)
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of the complete PKCS#11 object
+//   search sequence: C_FindObjectsInit, C_FindObjects, and C_FindObjectsFinal.
+//   It evaluates how efficiently a token can locate individual objects by
+//   label attribute in a populated object database, with randomized access
+//   patterns to defeat caching optimizations.
+//
+// PAYLOAD:
+//   The payload size specifies the number of temporary AES-256 session objects
+//   to create in the token as the search corpus. Each object has a unique
+//   sequential label (e.g., "label-tmp-000000" through "label-tmp-00NNNN").
+//   The payload size directly determines the search space complexity, with
+//   larger values creating more objects to search through. Maximum supported
+//   payload is 512 objects by default, configurable via P11PERFTEST_FIND_MAXOBJS
+//   environment variable.
+//
+// KEY REQUIREMENTS:
+//   - No pre-existing keys are required; the test creates its own corpus
+//   - Temporary objects: CKK_AES secret keys (generated, not imported)
+//   - Object attributes: CKA_TOKEN=FALSE (session objects), CKA_CLASS=SecretKey
+//   - Each object gets a unique label for identification
+//   - All temporary objects are destroyed during teardown
+//
+// OPTIONS:
+//   --payload <number>     : Number of objects to create and search through
+//                            (default max: 512, override with P11PERFTEST_FIND_MAXOBJS)
+//   Environment variable:
+//   P11PERFTEST_FIND_MAXOBJS : Override maximum allowed payload size
+//
+// TESTING APPROACH:
+//   The test uses a clever optimization to minimize overhead while maximizing
+//   search realism:
+//   
+//   PREPARATION PHASE:
+//   - Generates N temporary AES keys (N = payload size) via C_GenerateKey
+//   - Labels follow pattern: "<thread_label>-tmp-XXXXXX" (6-digit index)
+//   - Pre-generates 512 random target indices to search for in benchmark loop
+//   - Creates a reusable search template with attribute: CKA_CLASS=SecretKey,
+//     CKA_LABEL="<thread_label>-tmp-000000" (initial value)
+//
+//   BENCHMARK LOOP (crashtestdummy):
+//   - Selects next random target index (cycling through pre-generated list)
+//   - OPTIMIZATION: Directly modifies only the last 6 digits of the label
+//     string in the existing search template (avoids template reconstruction)
+//   - Executes complete search sequence:
+//     1. C_FindObjectsInit with modified template
+//     2. C_FindObjects requesting 1 object
+//     3. C_FindObjectsFinal
+//   - Verifies exactly 1 object found (throws NotFound exception otherwise)
+//   - Random access pattern prevents token-side caching optimizations
+//
+//   TEARDOWN PHASE:
+//   - Destroys all temporary objects via C_DestroyObject
+//
+//   This test is critical for evaluating token database/index performance,
+//   particularly relevant for smart cards and HSMs with object storage.
+//   The metric is complete search operations per second.
+//
+// ============================================================================
 
 class P11FindObjectsBenchmark : public P11Benchmark
 {

--- a/src/p11genrandom.hpp
+++ b/src/p11genrandom.hpp
@@ -21,6 +21,39 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: Random Number Generation (C_GenerateRandom)
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of the token's random number
+//   generator. It generates random bytes using the C_GenerateRandom function,
+//   which is a fundamental PKCS#11 operation for creating cryptographic
+//   random data.
+//
+// PAYLOAD:
+//   The payload size represents the number of random bytes to generate in
+//   each operation. The test generates a buffer of the specified size filled
+//   with cryptographically secure random data. The payload size is
+//   configurable via command-line options.
+//
+// KEY REQUIREMENTS:
+//   - No keys are required for this test case
+//   - The test operates directly with the PKCS#11 session
+//
+// OPTIONS:
+//   --payload <bytes>   : Number of random bytes to generate per operation
+//
+// TESTING APPROACH:
+//   The test calls C_GenerateRandom directly on the PKCS#11 session without
+//   requiring any key material. During preparation, a buffer of the requested
+//   size is allocated. The benchmark loop repeatedly generates random data,
+//   measuring the number of operations per second and the throughput in
+//   bytes/second. This test is useful for evaluating the performance of
+//   hardware random number generators (HRNGs) or the token's RNG implementation.
+//   The quality of randomness is not measured, only the generation speed.
+//
+// ============================================================================
 
 class P11GenerateRandomBenchmark : public P11Benchmark
 {

--- a/src/p11hmacsha1.hpp
+++ b/src/p11hmacsha1.hpp
@@ -21,6 +21,40 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: HMAC-SHA1 Message Authentication
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of HMAC (Hash-based Message
+//   Authentication Code) using SHA-1 as the underlying hash function. It
+//   computes authentication tags for variable-size payloads using the
+//   CKM_SHA_1_HMAC mechanism.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. HMAC can
+//   process messages of any length. The payload size is specified via
+//   command-line options. The output is a 20-byte (160-bit) digest.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_GENERIC_SECRET (generic secret key)
+//   - Key size: Typically matches or exceeds the hash output size (≥20 bytes)
+//   - The key must support HMAC/signing operations
+//   - Key attributes: CKA_SIGN must be set to CK_TRUE
+//
+// OPTIONS:
+//   --payload <bytes>   : Size of data to authenticate (any size supported)
+//
+// TESTING APPROACH:
+//   The test performs HMAC operations in a tight loop using C_Sign.
+//   Each iteration computes the HMAC-SHA1 of the payload, producing a
+//   20-byte authentication tag. The performance metric is the number of
+//   HMAC operations per second and data throughput. Note: SHA-1 is
+//   considered weak for cryptographic purposes but may still be used
+//   for performance comparison.
+//
+// ============================================================================
+
 class P11HMACSHA1Benchmark : public P11Benchmark
 {
     static constexpr auto m_digest_size = 20;

--- a/src/p11hmacsha256.hpp
+++ b/src/p11hmacsha256.hpp
@@ -21,6 +21,39 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: HMAC-SHA256 Message Authentication
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of HMAC (Hash-based Message
+//   Authentication Code) using SHA-256 as the underlying hash function. It
+//   computes authentication tags for variable-size payloads using the
+//   CKM_SHA256_HMAC mechanism.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. HMAC can
+//   process messages of any length. The payload size is specified via
+//   command-line options. The output is a 32-byte (256-bit) digest.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_GENERIC_SECRET (generic secret key)
+//   - Key size: Typically matches or exceeds the hash output size (≥32 bytes)
+//   - The key must support HMAC/signing operations
+//   - Key attributes: CKA_SIGN must be set to CK_TRUE
+//
+// OPTIONS:
+//   --payload <bytes>   : Size of data to authenticate (any size supported)
+//
+// TESTING APPROACH:
+//   The test performs HMAC operations in a tight loop using C_Sign.
+//   Each iteration computes the HMAC-SHA256 of the payload, producing a
+//   32-byte authentication tag. The performance metric is the number of
+//   HMAC operations per second and data throughput. SHA-256 is currently
+//   recommended for most authentication use cases.
+//
+// ============================================================================
+
 class P11HMACSHA256Benchmark : public P11Benchmark
 {
     static constexpr auto m_digest_size = 32;

--- a/src/p11hmacsha512.hpp
+++ b/src/p11hmacsha512.hpp
@@ -21,6 +21,39 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: HMAC-SHA512 Message Authentication
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of HMAC (Hash-based Message
+//   Authentication Code) using SHA-512 as the underlying hash function. It
+//   computes authentication tags for variable-size payloads using the
+//   CKM_SHA512_HMAC mechanism.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. HMAC can
+//   process messages of any length. The payload size is specified via
+//   command-line options. The output is a 64-byte (512-bit) digest.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_GENERIC_SECRET (generic secret key)
+//   - Key size: Typically matches or exceeds the hash output size (≥64 bytes)
+//   - The key must support HMAC/signing operations
+//   - Key attributes: CKA_SIGN must be set to CK_TRUE
+//
+// OPTIONS:
+//   --payload <bytes>   : Size of data to authenticate (any size supported)
+//
+// TESTING APPROACH:
+//   The test performs HMAC operations in a tight loop using C_Sign.
+//   Each iteration computes the HMAC-SHA512 of the payload, producing a
+//   64-byte authentication tag. The performance metric is the number of
+//   HMAC operations per second and data throughput. SHA-512 provides
+//   stronger security guarantees at the cost of larger output size.
+//
+// ============================================================================
+
 class P11HMACSHA512Benchmark : public P11Benchmark
 {
     static constexpr auto m_digest_size = 64;

--- a/src/p11jwe.cpp
+++ b/src/p11jwe.cpp
@@ -135,13 +135,11 @@ void P11JWEBenchmark::prepare(Session &session, Object &obj, std::optional<size_
     auto pubk_handles = Object::search<Object>( session, pubkey_search_template.attributes() );
 
     if( pubk_handles.size()==0 ) {
-	std::cerr << "Error: no public key found for label '" << label << "'" << std::endl;
-	throw std::string("Error: no public key found for given label"); // TODO fix
+        throw benchmark_result::NotFound(label);
     }
 
     if( pubk_handles.size()>1) {
-	std::cerr << "Error: more than one public key found for label '" << label << "'" << std::endl;
-	throw std::string("Error: more than one public key found for given label"); // TODO fix
+        throw benchmark_result::AmbiguousResult(label);
     }
 
     // OK now let's wrap the key

--- a/src/p11jwe.hpp
+++ b/src/p11jwe.hpp
@@ -23,6 +23,51 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: JWE Decryption (JSON Web Encryption - RFC 7516)
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of JWE (JSON Web Encryption)
+//   decryption, which combines asymmetric key unwrapping with symmetric
+//   authenticated encryption. It implements the RSA-OAEP + AES-GCM algorithm
+//   combination commonly used in JWE, performing both key unwrap and content
+//   decryption operations.
+//
+// PAYLOAD:
+//   The payload is the encrypted content (ciphertext) that will be decrypted
+//   after unwrapping the content encryption key (CEK). The payload size is
+//   configurable and represents the size of the encrypted data. The test
+//   simulates a complete JWE decryption workflow.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_RSA (RSA private key for CEK unwrapping)
+//   - Key sizes: Common RSA key sizes (2048, 3072, 4096 bits)
+//   - The key must support unwrap operations (CKA_UNWRAP = TRUE)
+//   - A temporary AES key (CEK) is unwrapped and used for content decryption
+//   - AES key sizes: 128, 192, or 256 bits (configurable via SymAlg)
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the RSA key size (2048, 3072, 4096)
+//   --payload <bytes>   : Size of encrypted content to decrypt
+//   Hash algorithm (SHA1/SHA256) and symmetric algorithm (AES-128/192/256-GCM)
+//   are configurable via constructor parameters
+//
+// TESTING APPROACH:
+//   The test implements a two-step JWE decryption process:
+//   1. KEY UNWRAP: Uses RSA-OAEP to unwrap the encrypted Content Encryption
+//      Key (CEK), importing it as an AES key into the token
+//   2. CONTENT DECRYPTION: Uses AES-GCM with the unwrapped CEK to decrypt
+//      the actual payload content
+//   During preparation, both the wrapped CEK and encrypted content are
+//   generated. The benchmark loop performs the complete two-step decryption,
+//   measuring the combined throughput. This test is particularly relevant
+//   for applications using JWE for secure message exchange, such as OAuth2
+//   tokens or encrypted API payloads. The performance includes both asymmetric
+//   and symmetric operations, providing a realistic end-to-end metric.
+//
+// ============================================================================
+
 // this class implements JWE decryption, using RSA-OAEP and AESGCM
 class P11JWEBenchmark : public P11Benchmark
 {

--- a/src/p11oaepdec.cpp
+++ b/src/p11oaepdec.cpp
@@ -62,6 +62,18 @@ inline P11OAEPDecryptBenchmark *P11OAEPDecryptBenchmark::clone() const {
     return new P11OAEPDecryptBenchmark{*this};
 }
 
+bool P11OAEPDecryptBenchmark::is_payload_supported(size_t payload_size)
+{
+    // OAEP max payload = modulus_size - 2*hash_len - 2
+    // Return true if modulus size not yet known (will be checked in prepare)
+    if (m_modulus_size_bytes == 0) return true;
+    
+    size_t hash_len = (m_hashalg == HashAlg::SHA1) ? 20 : 32;
+    size_t max_payload = m_modulus_size_bytes - 2 * hash_len - 2;
+    
+    return payload_size <= max_payload;
+}
+
 void P11OAEPDecryptBenchmark::prepare(Session &session, Object &obj, std::optional<size_t> threadindex)
 {
 
@@ -88,9 +100,11 @@ void P11OAEPDecryptBenchmark::prepare(Session &session, Object &obj, std::option
     }
 
     // OK now let's encrypt the payload
+    // Retrieve modulus size from the RSA public key
+    auto modulus = pubk_handles[0].get_attribute_value(AttributeType::Modulus);
+    m_modulus_size_bytes = modulus.size();
 
-    m_encrypted.resize(512);	// TODO infer size from modulus size
-    // TODO check also if payload does not exceed maximum size
+    m_encrypted.resize(m_modulus_size_bytes);
 
     // adjust PKCS OAEP params
     switch(m_hashalg) {

--- a/src/p11oaepdec.cpp
+++ b/src/p11oaepdec.cpp
@@ -97,15 +97,13 @@ void P11OAEPDecryptBenchmark::prepare(Session &session, Object &obj, std::option
     pubkey_search_template.add_class( ObjectClass::PublicKey );
 
     auto pubk_handles = Object::search<Object>( session, pubkey_search_template.attributes() );
-
+ 
     if( pubk_handles.size()==0 ) {
-	std::cerr << "Error: no public key found for label '" << label << "'" << std::endl;
-	throw std::string("Error: no public key found for given label"); // TODO fix
+        throw benchmark_result::NotFound(label);
     }
 
     if( pubk_handles.size()>1) {
-	std::cerr << "Error: more than one public key found for label '" << label << "'" << std::endl;
-	throw std::string("Error: more than one public key found for given label"); // TODO fix
+        throw benchmark_result::AmbiguousResult(label);
     }
 
     // OK now let's encrypt the payload

--- a/src/p11oaepdec.cpp
+++ b/src/p11oaepdec.cpp
@@ -66,9 +66,18 @@ bool P11OAEPDecryptBenchmark::is_payload_supported(size_t payload_size)
 {
     // OAEP max payload = modulus_size - 2*hash_len - 2
     // Return true if modulus size not yet known (will be checked in prepare)
-    if (m_modulus_size_bytes == 0) return true;
+    if (m_modulus_size_bytes == 0) { 
+	return true;
+    }
     
     size_t hash_len = (m_hashalg == HashAlg::SHA1) ? 20 : 32;
+    
+    // Ensure modulus size is large enough to support OAEP with this hash;  
+    // otherwise, any payload would be unsupported.  
+    if (m_modulus_size_bytes < 2 * hash_len + 2) {  
+        return false;  
+    }
+
     size_t max_payload = m_modulus_size_bytes - 2 * hash_len - 2;
     
     return payload_size <= max_payload;
@@ -103,6 +112,10 @@ void P11OAEPDecryptBenchmark::prepare(Session &session, Object &obj, std::option
     // Retrieve modulus size from the RSA public key
     auto modulus = pubk_handles[0].get_attribute_value(AttributeType::Modulus);
     m_modulus_size_bytes = modulus.size();
+
+    if( !is_payload_supported( m_payload.size() ) ) {
+        throw benchmark_result::PayloadSizeNotSupported(m_payload.size());
+    }
 
     m_encrypted.resize(m_modulus_size_bytes);
 

--- a/src/p11oaepdec.hpp
+++ b/src/p11oaepdec.hpp
@@ -35,6 +35,7 @@ private:
     HashAlg m_hashalg;		// algorithm used for hashing and MGF (OAEP)
     std::vector<uint8_t> m_encrypted; // encrypted data
     ObjectHandle  m_objhandle;	      // handle to RSA key
+    size_t m_modulus_size_bytes = 0;  // RSA modulus size in bytes
 
     // OAEP param structure used to wrap/unwrap symmetric key
     CK_RSA_PKCS_OAEP_PARAMS m_rsa_pkcs_oaep_params {
@@ -50,6 +51,7 @@ private:
     virtual void prepare(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual void crashtestdummy(Session &session) override;
     virtual P11OAEPDecryptBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11oaepdec.hpp
+++ b/src/p11oaepdec.hpp
@@ -18,6 +18,46 @@
 
 // p11oaepdec: PKCS#11 OAEP decryption (i.e. not unwrapping!)
 
+// ============================================================================
+// TEST CASE: RSA PKCS#1 OAEP Decryption
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of RSA decryption using the
+//   PKCS#1 OAEP (Optimal Asymmetric Encryption Padding) scheme. It decrypts
+//   a pre-encrypted payload using the CKM_RSA_PKCS_OAEP mechanism with a
+//   configurable hash algorithm for both the hash function and MGF.
+//
+// PAYLOAD:
+//   The payload consists of random data of configurable size. The maximum
+//   supported payload size is constrained by the RSA modulus and hash
+//   algorithm: max_payload = modulus_size_bytes - 2 * hash_len - 2.
+//   During preparation, the payload is encrypted with the matching RSA
+//   public key; the benchmark loop then performs the decryption operation.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_RSA (private key)
+//   - Key sizes: any RSA modulus size (e.g. 1024, 2048, 3072, 4096 bits)
+//   - The token must also have a matching RSA public key with the same label
+//     (used during the prepare phase to encrypt the payload)
+//   - Key attributes: CKA_DECRYPT must be set to CK_TRUE
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the RSA key size (e.g. 2048, 4096)
+//   --payload <bytes>   : Size of data to decrypt (bounded by OAEP overhead)
+//   --hash <alg>        : Hash algorithm to use: sha1 (default) or sha256
+//
+// TESTING APPROACH:
+//   During prepare(), the matching RSA public key is located by label and
+//   used to encrypt the payload via C_Encrypt with CKM_RSA_PKCS_OAEP. The
+//   benchmark loop (crashtestdummy) then calls C_DecryptInit / C_Decrypt
+//   repeatedly, measuring the throughput of the OAEP decryption operation.
+//   The hash algorithm controls both the OAEP hash (hashAlg) and the mask
+//   generation function (MGF): SHA-1 uses CKG_MGF1_SHA1, SHA-256 uses
+//   CKG_MGF1_SHA256.
+//
+// ============================================================================
+
 #if !defined P11OAEPDEC_HPP
 #define P11OAEPDEC_HPP
 

--- a/src/p11oaepenc.cpp
+++ b/src/p11oaepenc.cpp
@@ -69,6 +69,13 @@ bool P11OAEPEncryptBenchmark::is_payload_supported(size_t payload_size)
     if (m_modulus_size_bytes == 0) return true;
     
     size_t hash_len = (m_hashalg == HashAlg::SHA1) ? 20 : 32;
+
+    // Ensure modulus size is large enough to support OAEP with this hash;
+    // otherwise, any payload would be unsupported.
+    if (m_modulus_size_bytes < 2 * hash_len + 2) {
+        return false;
+    }
+
     size_t max_payload = m_modulus_size_bytes - 2 * hash_len - 2;
     
     return payload_size <= max_payload;

--- a/src/p11oaepenc.hpp
+++ b/src/p11oaepenc.hpp
@@ -23,6 +23,44 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: RSA-OAEP Encryption
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of RSA encryption using the
+//   Optimal Asymmetric Encryption Padding (OAEP) scheme. It encrypts
+//   variable-size payloads using the CKM_RSA_PKCS_OAEP mechanism with
+//   configurable hash algorithms.
+//
+// PAYLOAD:
+//   The payload is the plaintext data to be encrypted. The maximum payload
+//   size is constrained by the RSA modulus size and OAEP overhead:
+//   max_payload = modulus_size - 2*hash_size - 2
+//   For example, with 2048-bit RSA and SHA-1 (20 bytes), max is ~214 bytes.
+//   The payload size is validated using is_payload_supported().
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_RSA (RSA public key)
+//   - Key sizes: Common RSA key sizes (2048, 3072, 4096 bits)
+//   - The key must support encryption operations
+//   - Key attributes: CKA_ENCRYPT must be set to CK_TRUE
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the RSA key size (2048, 3072, 4096)
+//   --payload <bytes>   : Size of data to encrypt (limited by modulus size)
+//   Hash algorithm is configurable via constructor (SHA1 or SHA256)
+//
+// TESTING APPROACH:
+//   The test uses the CKM_RSA_PKCS_OAEP mechanism with configurable hash
+//   algorithm and MGF (Mask Generation Function). During preparation, the
+//   RSA public key is loaded and the OAEP parameters are configured with
+//   the chosen hash algorithm. The benchmark loop repeatedly encrypts the
+//   payload, measuring encryption operations per second. OAEP provides
+//   better security than PKCS#1 v1.5 padding.
+//
+// ============================================================================
+
 class P11OAEPEncryptBenchmark : public P11Benchmark
 {
 public:

--- a/src/p11oaepenc.hpp
+++ b/src/p11oaepenc.hpp
@@ -35,6 +35,7 @@ private:
     HashAlg m_hashalg;		// algorithm used for hashing and MGF (OAEP)
     std::vector<uint8_t> m_encrypted; // encrypted data
     ObjectHandle  m_objhandle;	      // handle to RSA key
+    size_t m_modulus_size_bytes = 0;  // RSA modulus size in bytes
 
     // OAEP param structure used to wrap/unwrap symmetric key
     CK_RSA_PKCS_OAEP_PARAMS m_rsa_pkcs_oaep_params {
@@ -50,6 +51,7 @@ private:
     virtual void prepare(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual void crashtestdummy(Session &session) override;
     virtual P11OAEPEncryptBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11oaepunw.cpp
+++ b/src/p11oaepunw.cpp
@@ -66,9 +66,18 @@ bool P11OAEPUnwrapBenchmark::is_payload_supported(size_t payload_size)
 {
     // OAEP max payload = modulus_size - 2*hash_len - 2
     // Return true if modulus size not yet known (will be checked in prepare)
-    if (m_modulus_size_bytes == 0) return true;
+    if (m_modulus_size_bytes == 0) { 
+	return true;
+    }
     
     size_t hash_len = (m_hashalg == HashAlg::SHA1) ? 20 : 32;
+    
+    // Ensure modulus size is large enough to support OAEP with this hash;  
+    // otherwise, any payload would be unsupported.  
+    if (m_modulus_size_bytes < 2 * hash_len + 2) {  
+        return false;  
+    }
+
     size_t max_payload = m_modulus_size_bytes - 2 * hash_len - 2;
     
     return payload_size <= max_payload;
@@ -78,29 +87,10 @@ void P11OAEPUnwrapBenchmark::prepare(Session &session, Object &obj, std::optiona
 {
     Byte btrue = CK_TRUE;
     Byte bfalse = CK_FALSE;
-    ObjectHandle symkey_handle;
     Mechanism mech_generic_secret_key_gen { CKM_GENERIC_SECRET_KEY_GEN, nullptr, 0 };
     Ulong keylen;
 
     m_objhandle = obj.handle();	// RSA key handle stored at m_objhandle
-
-    // we need to wrap a key, that we create.
-    // we don't use the payload, but we take payload size to generate a new key
-    // for more flexibility, we generate a CKK_GENERIC_SECRET key
-
-    keylen = m_payload.size();
-
-    std::array<Attribute,6> genseckeytemplate {
-	{
-	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Token), &bfalse, sizeof(Byte) },
-	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Private), &btrue, sizeof(Byte) },
-	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Derive), &btrue, sizeof(Byte) },
-	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Extractable), &btrue, sizeof(Byte) },
-	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::ValueLen), &keylen, sizeof(Ulong) }
-	}
-    };
-
-    session.module()->C_GenerateKey(session.handle(), &mech_generic_secret_key_gen, genseckeytemplate.data(), genseckeytemplate.size(), &symkey_handle );
 
     // retrieve the public key matching our object private key
     AttributeContainer pubkey_search_template;
@@ -126,6 +116,29 @@ void P11OAEPUnwrapBenchmark::prepare(Session &session, Object &obj, std::optiona
     // Retrieve modulus size from the RSA public key
     auto modulus = pubk_handles[0].get_attribute_value(AttributeType::Modulus);
     m_modulus_size_bytes = modulus.size();
+
+    if( !is_payload_supported( m_payload.size() ) ) {
+        throw benchmark_result::PayloadSizeNotSupported(m_payload.size());
+    }
+
+    keylen = m_payload.size();
+
+    // we need to wrap a key, that we create.
+    // we don't use the payload, we instead use the payload size to generate a new key
+    // for maximum flexibility, we generate a CKK_GENERIC_SECRET key
+
+    std::array<Attribute,5> genseckeytemplate {
+	{
+	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Token), &bfalse, sizeof(Byte) },
+	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Private), &btrue, sizeof(Byte) },
+	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Derive), &btrue, sizeof(Byte) },
+	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::Extractable), &btrue, sizeof(Byte) },
+	    { static_cast<CK_ATTRIBUTE_TYPE>(AttributeType::ValueLen), &keylen, sizeof(Ulong) }
+	}
+    };
+
+    ObjectHandle symkey_handle;
+    session.module()->C_GenerateKey(session.handle(), &mech_generic_secret_key_gen, genseckeytemplate.data(), genseckeytemplate.size(), &symkey_handle );
 
     m_wrapped.resize(m_modulus_size_bytes);
 

--- a/src/p11oaepunw.cpp
+++ b/src/p11oaepunw.cpp
@@ -103,13 +103,11 @@ void P11OAEPUnwrapBenchmark::prepare(Session &session, Object &obj, std::optiona
     auto pubk_handles = Object::search<Object>( session, pubkey_search_template.attributes() );
 
     if( pubk_handles.size()==0 ) {
-	std::cerr << "Error: no public key found for label '" << label << "'" << std::endl;
-	throw std::string("Error: no public key found for given label"); // TODO fix
+        throw benchmark_result::NotFound(label);
     }
 
     if( pubk_handles.size()>1) {
-	std::cerr << "Error: more than one public key found for label '" << label << "'" << std::endl;
-	throw std::string("Error: more than one public key found for given label"); // TODO fix
+        throw benchmark_result::AmbiguousResult(label);
     }
 
     // OK now let's wrap the key

--- a/src/p11oaepunw.hpp
+++ b/src/p11oaepunw.hpp
@@ -23,6 +23,45 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: RSA-OAEP Unwrap
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of RSA key unwrapping using the
+//   Optimal Asymmetric Encryption Padding (OAEP) scheme. Unlike decryption,
+//   unwrap imports encrypted key material directly into the token as a new
+//   key object using the CKM_RSA_PKCS_OAEP mechanism.
+//
+// PAYLOAD:
+//   The payload represents the size of the symmetric key being unwrapped
+//   (e.g., 16, 24, or 32 bytes for AES-128/192/256). During preparation,
+//   a temporary key is wrapped using RSA-OAEP encryption. The benchmark
+//   then measures unwrapping this encrypted key material back into the token.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_RSA (RSA private key for unwrapping)
+//   - Key sizes: Common RSA key sizes (2048, 3072, 4096 bits)
+//   - The key must support unwrap operations
+//   - Key attributes: CKA_UNWRAP must be set to CK_TRUE
+//   - The unwrapped key will be of type CKK_AES
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the RSA key size (2048, 3072, 4096)
+//   --payload <bytes>   : Size of symmetric key to unwrap (16, 24, or 32)
+//   Hash algorithm is configurable via constructor (SHA1 or SHA256)
+//
+// TESTING APPROACH:
+//   During preparation, a temporary AES key is created and wrapped using
+//   the RSA public key with OAEP padding. The wrapped material is stored
+//   in m_wrapped. The benchmark loop repeatedly unwraps this key material,
+//   creating new key objects in the token, then destroys them in cleanup.
+//   This tests the performance of C_UnwrapKey, which is commonly used in
+//   key transport scenarios. The unwrap operation includes both RSA
+//   decryption and key object creation.
+//
+// ============================================================================
+
 class P11OAEPUnwrapBenchmark : public P11Benchmark
 {
 public:

--- a/src/p11oaepunw.hpp
+++ b/src/p11oaepunw.hpp
@@ -36,6 +36,7 @@ private:
     std::vector<uint8_t> m_wrapped;   // wrapped key material
     ObjectHandle  m_objhandle;	      // handle to RSA key
     ObjectHandle  m_unwrappedhandle;  // handle to unwrapped key
+    size_t m_modulus_size_bytes = 0;  // RSA modulus size in bytes
 
     // OAEP param structure used to wrap/unwrap symmetric key
     CK_RSA_PKCS_OAEP_PARAMS m_rsa_pkcs_oaep_params {
@@ -51,6 +52,7 @@ private:
     virtual void prepare(Session &session, Object &obj, std::optional<size_t> threadindex) override;
     virtual void crashtestdummy(Session &session) override;
     virtual P11OAEPUnwrapBenchmark *clone() const override;
+    virtual bool is_payload_supported(size_t payload_size) override;
 
 public:
 

--- a/src/p11perftest.cpp
+++ b/src/p11perftest.cpp
@@ -612,8 +612,8 @@ int main(int argc, char **argv)
 	    }
 
 	    // JWE ( RSA OAEP + AES GCM )
-		// for JWE, we don't need to check has_key("") for AES, as these are session keys generated on the fly for each iteration of the benchmark, 
-		// and not persistent keys generated beforehand. We only check for the presence of RSA keys, which are needed for the key encryption step of JWE.
+	    // for JWE, we don't need to check has_key("") for AES, as these are session keys generated on the fly for each iteration of the benchmark, 
+	    // and not persistent keys generated beforehand. We only check for the presence of RSA keys, which are needed for the key encryption step of JWE.
 	    if(tests.contains("jwe") || tests.contains("jweoaepsha1")) {
 		if(keysizes.contains("rsa2048") && has_key("rsa-2048")) {
 		    if(keysizes.contains("aes128") )

--- a/src/p11perftest.cpp
+++ b/src/p11perftest.cpp
@@ -612,56 +612,58 @@ int main(int argc, char **argv)
 	    }
 
 	    // JWE ( RSA OAEP + AES GCM )
+		// for JWE, we don't need to check has_key("") for AES, as these are session keys generated on the fly for each iteration of the benchmark, 
+		// and not persistent keys generated beforehand. We only check for the presence of RSA keys, which are needed for the key encryption step of JWE.
 	    if(tests.contains("jwe") || tests.contains("jweoaepsha1")) {
 		if(keysizes.contains("rsa2048") && has_key("rsa-2048")) {
-		    if(keysizes.contains("aes128") && has_key("aes-128"))
+		    if(keysizes.contains("aes128") )
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-2048", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM128) );
-		    if(keysizes.contains("aes192") && has_key("aes-192"))
+		    if(keysizes.contains("aes192"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-2048", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM192) );
-		    if(keysizes.contains("aes256") && has_key("aes-256"))
+		    if(keysizes.contains("aes256"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-2048", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM256) );
 		}
 		if(keysizes.contains("rsa3072") && has_key("rsa-3072")) {
-		    if(keysizes.contains("aes128") && has_key("aes-128"))
+		    if(keysizes.contains("aes128"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-3072", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM128) );
-		    if(keysizes.contains("aes192") && has_key("aes-192"))
+		    if(keysizes.contains("aes192"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-3072", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM192) );
-		    if(keysizes.contains("aes256") && has_key("aes-256"))
+		    if(keysizes.contains("aes256"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-3072", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM256) );
 		}
 		if(keysizes.contains("rsa4096") && has_key("rsa-4096")) {
-		    if(keysizes.contains("aes128") && has_key("aes-128"))
+		    if(keysizes.contains("aes128"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-4096", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM128) );
-		    if(keysizes.contains("aes192") && has_key("aes-192"))
+		    if(keysizes.contains("aes192"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-4096", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM192) );
-		    if(keysizes.contains("aes256") && has_key("aes-256"))
+		    if(keysizes.contains("aes256"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-4096", vendor, P11JWEBenchmark::HashAlg::SHA1, P11JWEBenchmark::SymAlg::GCM256) );
 		}
 	    }
 
 	    if(tests.contains("jwe") || tests.contains("jweoaepsha256")) {
 		if(keysizes.contains("rsa2048") && has_key("rsa-2048")) {
-		    if(keysizes.contains("aes128") && has_key("aes-128"))
+		    if(keysizes.contains("aes128"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-2048", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM128) );
-		    if(keysizes.contains("aes192") && has_key("aes-192"))
+		    if(keysizes.contains("aes192"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-2048", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM192) );
-		    if(keysizes.contains("aes256") && has_key("aes-256"))
+		    if(keysizes.contains("aes256"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-2048", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM256) );
 		}
 		if(keysizes.contains("rsa3072") && has_key("rsa-3072")) {
-		    if(keysizes.contains("aes128") && has_key("aes-128"))
+		    if(keysizes.contains("aes128"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-3072", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM128) );
-		    if(keysizes.contains("aes192") && has_key("aes-192"))
+		    if(keysizes.contains("aes192"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-3072", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM192) );
-		    if(keysizes.contains("aes256") && has_key("aes-256"))
+		    if(keysizes.contains("aes256"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-3072", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM256) );
 		}
 		if(keysizes.contains("rsa4096") && has_key("rsa-4096")) {
-		    if(keysizes.contains("aes128") && has_key("aes-128"))
+		    if(keysizes.contains("aes128"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-4096", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM128) );
-		    if(keysizes.contains("aes192") && has_key("aes-192"))
+		    if(keysizes.contains("aes192"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-4096", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM192) );
-		    if(keysizes.contains("aes256") && has_key("aes-256"))
+		    if(keysizes.contains("aes256"))
 			benchmarks.emplace_front( new P11JWEBenchmark("rsa-4096", vendor, P11JWEBenchmark::HashAlg::SHA256, P11JWEBenchmark::SymAlg::GCM256) );
 		}
 	    }

--- a/src/p11rsapss.hpp
+++ b/src/p11rsapss.hpp
@@ -22,6 +22,42 @@
 #include "p11benchmark.hpp"
 #include <random>
 
+// ============================================================================
+// TEST CASE: RSA-PSS Signature Generation
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of RSA signature generation using
+//   the Probabilistic Signature Scheme (PSS) padding. It signs pre-computed
+//   hash values using the CKM_RSA_PKCS_PSS mechanism, which provides better
+//   security properties than PKCS#1 v1.5.
+//
+// PAYLOAD:
+//   The payload is a pre-computed hash of the data to be signed. The hash
+//   is generated externally and provided to the PSS signing operation.
+//   The hash algorithm and MGF (Mask Generation Function) are configured
+//   via the CK_RSA_PKCS_PSS_PARAMS structure.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_RSA (RSA private key)
+//   - Key sizes: Common RSA key sizes (2048, 3072, 4096 bits)
+//   - The key must be a private key with signing capabilities
+//   - Key attributes: CKA_SIGN must be set to CK_TRUE
+//   - The token must support the CKM_RSA_PKCS_PSS mechanism
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the RSA key size (2048, 3072, 4096)
+//
+// TESTING APPROACH:
+//   The test directly uses PKCS#11's C_Sign function with the PSS mechanism.
+//   During preparation, a hash value is computed using Botan's secure_vector.
+//   The PSS parameters (hash algorithm, MGF, and salt length) are configured
+//   in the mechanism structure. The benchmark loop repeatedly signs the hash,
+//   measuring signature operations per second. PSS adds randomness through
+//   salt, making each signature unique even for the same message.
+//
+// ============================================================================
+
 class P11RSAPssBenchmark : public P11Benchmark
 {
     static constexpr auto m_signature_size = 512; // Max RSA signature size (4096 bits)

--- a/src/p11rsasig.hpp
+++ b/src/p11rsasig.hpp
@@ -21,6 +21,41 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: RSA Signature Generation (PKCS#1 v1.5)
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of RSA signature generation using
+//   the PKCS#1 v1.5 padding scheme. It signs data using RSA private keys
+//   through the PKCS#11 interface with Botan's PK_Signer framework.
+//
+// PAYLOAD:
+//   The payload is the data to be signed. The Botan PK_Signer handles the
+//   hashing and padding internally according to the signature scheme
+//   (typically RSA with SHA-256 or SHA-512).
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_RSA (RSA private key)
+//   - Key sizes: Common RSA key sizes (1024, 2048, 3072, 4096 bits)
+//   - The key must be a private key with signing capabilities
+//   - Key attributes: CKA_SIGN must be set to CK_TRUE
+//   - The key must be accessible via PKCS#11 and usable with Botan's
+//     PKCS11_RSA_PrivateKey wrapper
+//
+// OPTIONS:
+//   --keysize <bits>    : Specifies the RSA key size (1024, 2048, 3072, 4096)
+//
+// TESTING APPROACH:
+//   The test uses Botan's PKCS#11 integration to wrap the RSA private key
+//   and create a PK_Signer object configured with the appropriate hash and
+//   padding scheme. The benchmark loop repeatedly signs the payload data,
+//   measuring the number of signature operations per second. RSA signing
+//   involves modular exponentiation with the private key, which is
+//   computationally intensive, especially for larger key sizes.
+//
+// ============================================================================
+
 class P11RSASigBenchmark : public P11Benchmark
 {
     Botan::AutoSeeded_RNG m_rng;

--- a/src/p11seedrandom.hpp
+++ b/src/p11seedrandom.hpp
@@ -21,6 +21,39 @@
 
 #include "p11benchmark.hpp"
 
+// ============================================================================
+// TEST CASE: Seed Random Number Generator (C_SeedRandom)
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of seeding the token's random
+//   number generator. It provides entropy to the RNG using the C_SeedRandom
+//   function, which mixes external random data into the generator's state.
+//
+// PAYLOAD:
+//   The payload size represents the number of seed bytes to provide to the
+//   RNG in each operation. The test generates random seed data (using a
+//   standard C++ random generator) and feeds it to the token's RNG. The
+//   payload size is configurable via command-line options.
+//
+// KEY REQUIREMENTS:
+//   - No keys are required for this test case
+//   - The test operates directly with the PKCS#11 session
+//
+// OPTIONS:
+//   --payload <bytes>   : Number of seed bytes to provide per operation
+//
+// TESTING APPROACH:
+//   The test calls C_SeedRandom on the PKCS#11 session, providing external
+//   entropy. During preparation, a buffer is allocated and filled with
+//   random data to use as seed material. The benchmark loop repeatedly
+//   seeds the RNG with this data, measuring the number of seeding operations
+//   per second. This test evaluates how quickly a token can accept and
+//   process entropy, which is important for systems that need to frequently
+//   reseed their RNGs for security reasons. Note that not all tokens support
+//   or require seeding.
+//
+// ============================================================================
 
 class P11SeedRandomBenchmark : public P11Benchmark
 {

--- a/src/p11xorkeydataderive.hpp
+++ b/src/p11xorkeydataderive.hpp
@@ -21,12 +21,40 @@
 
 #include "p11benchmark.hpp"
 
-
-// typedef struct CK_KEY_DERIVATION_STRING_DATA {
-//   CK_BYTE_PTR pData;
-//   CK_ULONG    ulLen;
-// } CK_KEY_DERIVATION_STRING_DATA;
-
+// ============================================================================
+// TEST CASE: XOR Base and Data Key Derivation (CKM_XOR_BASE_AND_DATA)
+// ============================================================================
+//
+// DESCRIPTION:
+//   This test case measures the performance of key derivation using the
+//   XOR_BASE_AND_DATA mechanism. It derives new symmetric keys by XORing
+//   a base key with provided data, creating a derived key with the result.
+//
+// PAYLOAD:
+//   The payload is the XOR data (16 bytes) that will be XORed with the base
+//   key material. This data is fixed as a pattern (alternating 0x00 and 0xff)
+//   and is provided via the CK_KEY_DERIVATION_STRING_DATA structure.
+//
+// KEY REQUIREMENTS:
+//   - Key type: CKK_AES or CKK_GENERIC_SECRET (base key for derivation)
+//   - Key size: Must be 16 bytes (128 bits) to match the XOR data size
+//   - The base key must support key derivation operations
+//   - Key attributes: CKA_DERIVE must be set to CK_TRUE
+//   - The derived key will be of the same type (CKK_AES, 16 bytes)
+//
+// OPTIONS:
+//   No specific options; key size is fixed at 16 bytes for this test.
+//
+// TESTING APPROACH:
+//   The test uses the CKM_XOR_BASE_AND_DATA mechanism with a fixed 16-byte
+//   XOR pattern. During preparation, the base key handle is obtained and
+//   the derivation parameters are configured. The benchmark loop repeatedly
+//   derives new AES keys by XORing the base key with the data pattern,
+//   measuring derivation operations per second. After each iteration, the
+//   derived key is destroyed in the cleanup phase. This is a simple but
+//   efficient derivation method useful for key diversification.
+//
+// ============================================================================
 
 class P11XorKeyDataDeriveBenchmark : public P11Benchmark
 {


### PR DESCRIPTION
This pull request introduces improved payload validation and error handling for cryptographic benchmark tests, ensuring that only supported payload sizes are processed for each encryption mode. It also adds detailed documentation for each benchmark class, clarifying requirements and testing approaches. The most important changes are grouped below.

### Enhanced error handling and outcome reporting

* Added new exception types (`NotFound`, `AmbiguousResult`, `PayloadSizeNotSupported`) to `benchmark_result` for more descriptive error reporting, and updated the `operation_outcome_t` variant to include them.
* Updated the `execute` method in `P11Benchmark` to throw and handle these new exceptions, including unified error printing and outcome assignment. [[1]](diffhunk://#diff-2cf635ed249eec64f2cdd69c90c433adddce656a44021f63bb06c71f41846e9aR109-R115) [[2]](diffhunk://#diff-2cf635ed249eec64f2cdd69c90c433adddce656a44021f63bb06c71f41846e9aL121-R140) [[3]](diffhunk://#diff-2cf635ed249eec64f2cdd69c90c433adddce656a44021f63bb06c71f41846e9aR164-R169)
* Modified the `errorcode` function to return descriptive error messages for new outcome types.

### Payload validation for benchmarks

* Introduced the `is_payload_supported` virtual method in `P11Benchmark`, allowing each benchmark to specify payload size requirements; implemented this method in all AES and DES3 benchmark subclasses to enforce block size constraints. [[1]](diffhunk://#diff-bf40b474aa8362a1ee3e8a8b9219f5145f50f0333b59fc087233866bad3e5187R66) [[2]](diffhunk://#diff-677f3fa5584d42cdddfb2522071bb56b7e2aa4ca63c8ccc5167271599ade67bdR66) [[3]](diffhunk://#diff-3703e6388934256cf0f186a2bfd1e3242ff757717782b8397bc0075c43cfa80eR26-R59) [[4]](diffhunk://#diff-357df7653aa73b47000a509516151dc365414a68096910010eaca476ff3b6a84R67) [[5]](diffhunk://#diff-d322166dab6c5a44a79a3c00e164a811988ce0a1bf8a999c623dd337d22b0fcaR65) [[6]](diffhunk://#diff-889f9effdc6c478324aec774168e1b7df9620d0e4b611b01fa041b8bb2c40b0cR185-R187) [[7]](diffhunk://#diff-4679ae4fe52894da2e2f140224f23b67227854d6b07ce1e1d54b7222ed23b88fR34-R38) [[8]](diffhunk://#diff-7909a51e501369dc693b0eee3cea773e3cd902fcd7618353067bfc9482edb4acR30-R34) [[9]](diffhunk://#diff-dce02b10d242efedb831d95e6b9ade28bc13aec1f77bb84ebebef30d9015a586R34-R38) [[10]](diffhunk://#diff-53fab3d440960477302ed9e1bb5e3a67dfa48f06dfe02b0ae260566679ede13fR30-R34)

### Documentation improvements

* Added detailed block comments to the header files of each benchmark class (`P11AESCBCBenchmark`, `P11AESECBBenchmark`, `P11AESGCMBenchmark`, `P11DES3CBCBenchmark`, `P11DES3ECBBenchmark`) describing test case purpose, payload requirements, key attributes, options, and testing methodology. [[1]](diffhunk://#diff-bf40b474aa8362a1ee3e8a8b9219f5145f50f0333b59fc087233866bad3e5187R24-R55) [[2]](diffhunk://#diff-677f3fa5584d42cdddfb2522071bb56b7e2aa4ca63c8ccc5167271599ade67bdR24-R56) [[3]](diffhunk://#diff-3703e6388934256cf0f186a2bfd1e3242ff757717782b8397bc0075c43cfa80eR26-R59) [[4]](diffhunk://#diff-357df7653aa73b47000a509516151dc365414a68096910010eaca476ff3b6a84R24-R56) [[5]](diffhunk://#diff-d322166dab6c5a44a79a3c00e164a811988ce0a1bf8a999c623dd337d22b0fcaR24-R55)

These changes collectively make the benchmarking framework more robust, user-friendly, and maintainable by enforcing correct payload sizes, providing clearer error messages, and documenting test requirements.